### PR TITLE
Bump outdated libraries

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file. This change
 
 == Unreleased (dev)
 
+== 0.2.8
+
+=== Changed
+* Bumped clojure to 1.12.4.
+* Bumped angus-mail to 2.0.5.
+* Bumped commons-codec to 1.20.0.
+* Bumped jakarta.mail-api to 2.1.5.
+* Bumped tika-core to 3.2.3.
+* Bumped deep-diff2 to 2.12.219.
+* Bumped data.json to 2.5.1.
+* Bumped http-kit to 2.8.1.
+
 == 0.2.7
 
 === Changed

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ install:
 test:
 	clojure -M:dev:1.9:test
 	clojure -M:dev:1.10:test
+	clojure -M:dev:1.11:test
 	clojure -M:dev:test
 
 .PHONY: test-unit
@@ -29,6 +30,7 @@ test-unit:
 test-integration:
 	clojure -M:dev:1.9:test it
 	clojure -M:dev:1.10:test it
+	clojure -M:dev:1.11:test it
 	clojure -M:dev:test it
 
 .PHONY: outdated

--- a/deps.edn
+++ b/deps.edn
@@ -1,17 +1,18 @@
 {:paths ["src" "resources"]
 
  :deps
- {org.clojure/clojure {:mvn/version "1.11.1"}
+ {org.clojure/clojure {:mvn/version "1.12.4"}
   camel-snake-kebab/camel-snake-kebab {:mvn/version "0.4.3"}
-  org.eclipse.angus/angus-mail {:mvn/version "2.0.3"}
-  commons-codec/commons-codec {:mvn/version "1.16.1"}
-  jakarta.mail/jakarta.mail-api {:mvn/version "2.1.3"}
+  org.eclipse.angus/angus-mail {:mvn/version "2.0.5"}
+  commons-codec/commons-codec {:mvn/version "1.20.0"}
+  jakarta.mail/jakarta.mail-api {:mvn/version "2.1.5"}
   nano-id/nano-id {:mvn/version "1.1.0"}
-  org.apache.tika/tika-core {:mvn/version "2.9.1"}}
+  org.apache.tika/tika-core {:mvn/version "3.2.3"}}
 
  :aliases
  {:1.9 {:override-deps {org.clojure/clojure {:mvn/version "1.9.0"}}}
   :1.10 {:override-deps {org.clojure/clojure {:mvn/version "1.10.3"}}}
+  :1.11 {:override-deps {org.clojure/clojure {:mvn/version "1.11.4"}}}
 
   :dev {:extra-deps {com.github.kirviq/dumbster {:mvn/version "1.7.1"}
                      testdoc/testdoc {:mvn/version "1.4.1"}
@@ -19,15 +20,15 @@
                      com.gearswithingears/shrubbery {:mvn/version "0.4.1"}
                      lambdaisland/kaocha {:mvn/version "1.91.1392"}
                      lambdaisland/kaocha-cloverage {:mvn/version "1.1.89"}
-                     lambdaisland/deep-diff2 {:mvn/version "2.11.216"}
+                     lambdaisland/deep-diff2 {:mvn/version "2.12.219"}
                      ;; for integration test
-                     org.clojure/data.json {:mvn/version "2.5.0"}
-                     http-kit/http-kit {:mvn/version "2.7.0"}}
+                     org.clojure/data.json {:mvn/version "2.5.1"}
+                     http-kit/http-kit {:mvn/version "2.8.1"}}
         :extra-paths ["test" "dev/src" "dev/resources"]}
 
   :test {:main-opts ["-m" "kaocha.runner"]}
 
-  :outdated {:extra-deps {com.github.liquidz/antq {:mvn/version "2.11.1276"}}
+  :outdated {:extra-deps {com.github.liquidz/antq {:mvn/version "2.11.1300"}}
              :main-opts ["-m" "antq.core"]}
 
   :build {:deps {com.github.liquidz/build.edn {:mvn/version "0.11.266"}}


### PR DESCRIPTION
cf. #23

While the `org.eclipse.angus/angus-activation` issue persists, we are holding off on applying the patch since the patched version is currently in development.

```
Dependency Information
-----------------------------------------------------
NAME: org.eclipse.angus/angus-activation
VERSION: 2.0.3

DEPENDENCY FOUND IN:

[org.eclipse.angus/angus-mail]


FIX SUGGESTION:
Vulnerabilities
-----------------------------------------------------

SEVERITY: HIGH
IDENTIFIERS: CVE-2025-7962
CVSS: 7.5 (version 3.1)
PATCHED VERSION: 2.1.0-M1
```